### PR TITLE
Extends Player entity attributes to surname, age, post, captain, coun…

### DIFF
--- a/soccer-records-persistence/src/main/java/soccer/records/dao/PlayerDao.java
+++ b/soccer-records-persistence/src/main/java/soccer/records/dao/PlayerDao.java
@@ -6,9 +6,10 @@ import soccer.records.entity.Player;
 
 public interface PlayerDao {
     public Player findById(Long id);
+    public Player findByPlayer(Player p);
     public void create(Player c);
     public void update(Player c);
     public void delete(Player c);
     public List<Player> findAll();
-    public List<Player> findByName(String name);
+    public List<Player> findByName(String name,  String surname);
 }

--- a/soccer-records-persistence/src/main/java/soccer/records/dao/PlayerDaoImpl.java
+++ b/soccer-records-persistence/src/main/java/soccer/records/dao/PlayerDaoImpl.java
@@ -22,6 +22,11 @@ public class PlayerDaoImpl implements PlayerDao {
 	public Player findById(Long id) {
             return em.find(Player.class, id);
 	}
+        
+        @Override
+        public Player findByPlayer(Player p){
+            return em.find(Player.class, p.getId());
+        }
 
 	@Override
 	public List<Player> findAll() {
@@ -44,9 +49,9 @@ public class PlayerDaoImpl implements PlayerDao {
 	}
 
 	@Override
-	public List<Player> findByName(String name) {
+	public List<Player> findByName(String name,  String surname) {
             try {
-                return em.createQuery("select p from Player p where p.name = :name",Player.class).setParameter("name", name).getResultList();
+                return em.createQuery("select p from Player p where p.name = :name AND p.surname = :surname",Player.class).setParameter("name", name).setParameter("surname", surname).getResultList();
             } catch (NoResultException nrf) {
                 return null;
             }

--- a/soccer-records-persistence/src/main/java/soccer/records/entity/Player.java
+++ b/soccer-records-persistence/src/main/java/soccer/records/entity/Player.java
@@ -6,6 +6,8 @@ import java.util.Set;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -13,98 +15,178 @@ import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.validation.constraints.NotNull;
+import soccer.records.enums.PlayerPost;
 
 /**
  *
  * @author Tomas Mazurek
  */
-
 @Entity
 public class Player {
-	
-	@Id
-	@GeneratedValue(strategy=GenerationType.IDENTITY)
-	private Long id;
-	
-	@NotNull
-	@Column(nullable=false,unique=true)
-	private String name;
-        
-        @ManyToOne()
-        private Team team;
-        
-        @OneToMany(mappedBy = "player")
-        private Set<PlayerResult> playerResults = new HashSet<PlayerResult>();
 
-	public Player(Long playerId) {
-		this.id = playerId; 
-	}
-        
-	public Player() {
-	}
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	public String getName() {
-		return name;
-	}
+    @NotNull
+    @Column(nullable = false)
+    private String name;
 
-	public void setName(String name) {
-		this.name = name;
-	}
+    @NotNull
+    @Column(nullable = false)
+    private String surname;
 
+    @NotNull
+    @Column(nullable = false)
+    private int age;
 
-	public Long getId() {
-		return id;
-	}
-        
-        public void setId(Long playerId) {
-            this.id = playerId; 
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    @Column(nullable = false)
+    private PlayerPost post;
+
+    @NotNull
+    @Column(nullable = false)
+    private boolean captian;
+
+    private String country;
+    private String city;
+
+    @ManyToOne()
+    private Team team;
+
+    @OneToMany(mappedBy = "player")
+    private Set<PlayerResult> playerResults = new HashSet<PlayerResult>();
+
+    public Player(Long playerId) {
+        this.id = playerId;
+    }
+
+    public Player() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long playerId) {
+        this.id = playerId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    public PlayerPost getPost() {
+        return post;
+    }
+
+    public void setPost(PlayerPost post) {
+        this.post = post;
+    }
+
+    public boolean isCaptian() {
+        return captian;
+    }
+
+    public void setCaptian(boolean captian) {
+        this.captian = captian;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public Set<PlayerResult> getPlayerResults() {
+        return playerResults;
+    }
+
+    public void setPlayerResults(Set<PlayerResult> playerResults) {
+        this.playerResults = playerResults;
+    }
+    
+    
+
+    public Long getTeamId() {
+        return team.getId();
+    }
+
+    public void setTeamId(Long teamId) {
+        this.team.setId(teamId);
+    }
+
+    public Team getTeam() {
+        return team;
+    }
+
+    public void setTeam(Team team) {
+        this.team = team;
+    }
+
+    public Team team() {
+        return this.team;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
         }
-        
-        public Long getTeamId() {
-            return team.getId();
+        if (obj == null) {
+            return false;
         }
-        
-        public void setTeamId(Long teamId) {
-            this.team.setId(teamId);
+        if (!(obj instanceof Player)) {
+            return false;
         }
-        
-        public Team getTeam() {
-            return team;
+        Player other = (Player) obj;
+        if (name == null) {
+            if (other.getName() != null) {
+                return false;
+            }
+        } else if (!name.equals(other.getName())) {
+            return false;
         }
-        
-        public void setTeam(Team team) {
-            this.team = team;
-        }
-        
-        public Team team() {
-            return this.team;
-        }
+        return true;
+    }
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((name == null) ? 0 : name.hashCode());
-		return result;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (! (obj instanceof Player))
-			return false;
-		Player other = (Player) obj;
-		if (name == null) {
-			if (other.getName() != null)
-				return false;
-		} else if (!name.equals(other.getName()))
-			return false;
-		return true;
-	}
-	
-	
-	
 }

--- a/soccer-records-persistence/src/main/java/soccer/records/enums/Neco.java
+++ b/soccer-records-persistence/src/main/java/soccer/records/enums/Neco.java
@@ -1,5 +1,0 @@
-package soccer.records.enums;
-
-public enum Neco {
-    CZK, EUR, USD
-}

--- a/soccer-records-persistence/src/main/java/soccer/records/enums/PlayerPost.java
+++ b/soccer-records-persistence/src/main/java/soccer/records/enums/PlayerPost.java
@@ -1,0 +1,5 @@
+package soccer.records.enums;
+
+public enum PlayerPost {
+    ATTACKER, MIDFIELDER, DEFENDER, GOLMAN
+}

--- a/soccer-records-persistence/src/main/java/soccer/records/services/PlayerServiceImpl.java
+++ b/soccer-records-persistence/src/main/java/soccer/records/services/PlayerServiceImpl.java
@@ -36,7 +36,7 @@ public class PlayerServiceImpl {
         playerDao.delete(p);
     }
 
-    public List<Player> findByName(String name) {
-        return playerDao.findByName(name);
+    public List<Player> findByName(String name, String surname) {
+        return playerDao.findByName(name, surname);
     }
 }

--- a/soccer-records-persistence/src/test/java/soccer/records/tests/PlayerTest.java
+++ b/soccer-records-persistence/src/test/java/soccer/records/tests/PlayerTest.java
@@ -3,6 +3,7 @@ package soccer.records.tests;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.PersistenceUnit;
+import javax.validation.ConstraintViolationException;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import org.springframework.test.context.ContextConfiguration;
@@ -17,8 +18,13 @@ import soccer.records.PersistenceAppContext;
 import soccer.records.dao.PlayerDao;
 
 import soccer.records.entity.Player;
+import soccer.records.enums.PlayerPost;
 import soccer.records.services.PlayerServiceImpl;
 
+/**
+ *
+ * @author Radim Vidlák
+ */
 @ContextConfiguration(classes = PersistenceAppContext.class)
 @TestExecutionListeners(TransactionalTestExecutionListener.class)
 @Transactional
@@ -37,15 +43,41 @@ public class PlayerTest extends AbstractTestNGSpringContextTests {
         this.pl = new Player();       
     } 
     
+    @Test(expectedExceptions = ConstraintViolationException.class)
+    public void notNullTest(){
+        
+        this.pl.setName("Karel");
+        this.playerService.create(pl);
+
+        this.pl.setSurname("Dvoøák");
+        this.playerService.create(pl);        
+
+        this.pl.setAge(30);
+        this.playerService.create(pl); 
+
+        this.pl.setPost(PlayerPost.ATTACKER);
+        this.playerService.create(pl); 
+        
+        /* correct
+        this.pl.setCaptian(false);
+        this.playerService.create(pl); 
+        */
+    }
+    
     @Test
     public void playerCreateTest() {
 
         EntityManager em = emf.createEntityManager();
         em.getTransaction().begin();
     
-        this.pl.setName("Karel Novák");
+        this.pl.setName("Karel");
+        this.pl.setSurname("Novák");
+        this.pl.setAge(30);
+        this.pl.setPost(PlayerPost.GOLMAN);
+        this.pl.setCaptian(false);
+        
         playerService.create(this.pl);
-        Assert.assertEquals(this.pl.getName(), playerService.findByName("Karel Novák").get(0).getName());
+        Assert.assertEquals(this.pl.getName(), playerService.findByName("Karel","Novák").get(0).getName());
         
         em.getTransaction().commit();
         em.close();
@@ -58,9 +90,10 @@ public class PlayerTest extends AbstractTestNGSpringContextTests {
         EntityManager em = emf.createEntityManager();
         em.getTransaction().begin();
 
-        this.pl.setName("Karel Bureš");       
+        this.pl.setName("Karel");
+        this.pl.setSurname("Bureš");
         playerService.update(this.pl);
-        Assert.assertEquals(this.pl.getName(), playerService.findByName("Karel Bureš").get(0).getName());
+        Assert.assertEquals(this.pl.getName(), playerService.findByName("Karel","Bureš").get(0).getName());
         
         em.getTransaction().commit();
         em.close();


### PR DESCRIPTION
Extends Player entity attributes to surname, age, post, captain, country and city. Change method findByName in Player Dao and service params from name to name and surname. Chanched PlayerTest to work correctly with new entity. Created new enum PlayerPost